### PR TITLE
feat: added a command to add an arrow  at cursor location

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,9 @@ export default class ArrowsPlugin extends Plugin {
 	extensions: Extension[];
 	userDefinedColorsDict: {[colorName: string]: string};
 
+	private arrowStarted = false;
+	private currArrowName = "";
+
 	async onload() {
 		await this.loadSettings();
 		this.addSettingTab(new ArrowsSettingTab(this.app, this));
@@ -19,13 +22,59 @@ export default class ArrowsPlugin extends Plugin {
 			arrowsViewPlugin.extension
 		];
 		this.registerEditorExtension(this.extensions);
+
+		this.addCommand({
+			id: 'insert-arrow-at-cursor',
+			name: 'Insert arrow at cursor location',
+			editorCallback: (editor) => {
+				let arrowString = this.arrowInsertConstructor()
+				const cursor = editor.getCursor();
+				editor.replaceRange(arrowString, cursor);
+			}
+		});
 	}
 
 	onunload() {
 		const leaderLineDefs = document.getElementById("leader-line-defs");
 		if (leaderLineDefs) leaderLineDefs.remove();
 	}
+	
+	arrowInsertConstructor() {
+		if (this.arrowStarted == false){
+			const randColor = this.getRandomPastel();
+			const currTimestamp = Date.now().toString();
+			this.arrowStarted = true
+			this.currArrowName = currTimestamp
+			
+			return `{${currTimestamp}|${randColor}}`;
+		} else {
+			this.arrowStarted = false
+			return `{${this.currArrowName}}`;
+		}
 
+	}
+
+	getRandomPastel(): string {
+		const softColors = [
+			"#6f8fae",
+			"#7b6fae",
+			"#6faea3",
+			"#aea36f",
+			"#ae7f6f",
+			"#6fae7f",
+			"#6f9fae",
+			"#a06fae",
+			"#9fae6f",
+			"#ae8f6f",
+			"#6f87ae",
+			"#8f8f8f"  
+		];
+
+		return softColors[
+			Math.floor(Math.random() * softColors.length)
+		];
+	}
+	
 	async loadSettings() {
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
 	}


### PR DESCRIPTION
Added a simple command which locates the cursor location and adds {currentTimestamp|randomPastelColor} there.

If an arrow has already been started by using the command, then the adds {currentTimestamp}, where the currentTimestamp is saved temporarily.

The only reason the currentTimestamp is being used, is that it ensures a unique name for each arrow. 

A future feature would be allowing users to provide their own list of colors to be used. I didn't implement that since i wasn't sure if that was in sync with the project flow/ your vision. 